### PR TITLE
fix: add missing semicolon in SCSS import build error

### DIFF
--- a/src/components/Auth/CallbackClient/styles.module.scss
+++ b/src/components/Auth/CallbackClient/styles.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/utils.module.scss"
+@import "../../../styles/utils.module.scss";
 
 .content {
   @extend .flexCol;


### PR DESCRIPTION
## 주요 변경 사항
SCSS의 @import 구문에 누락된 세미콜론 추가 -> SassError: expected ";" 빌드 에러 해결