### PR TITLE
fix: remove year parameter on initial year period selection to fetch data

### DIFF
--- a/src/lib/hooks/useAnalyticsHandlers.ts
+++ b/src/lib/hooks/useAnalyticsHandlers.ts
@@ -9,9 +9,11 @@ export const useAnalyticsHandlers = () => {
         setPeriod(newPeriod);
         const params: { period: typeof newPeriod; year?: number } = { period: newPeriod };
         if (newPeriod === 'year') {
-            params.year = selectedYear;
+            fetchAnalytics({ period: newPeriod });
+        } else {
+            delete params.year;
+            fetchAnalytics(params);
         }
-        fetchAnalytics(params);
     };
 
     const handleYearChange = (e: ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
## 변경사항
- `handlePeriodChange`에서 기간이 `year`일 경우 `year` 파라미터를 제거하도록 수정
- 초기 `year` 기간 선택 시 전체 데이터가 아닌 해당 기간(year)의 데이터만 가져오도록 변경
- 연도 선택은 `handleYearChange` 함수에서만 처리되도록 로직 분리

## 목적
- `year` 기간 선택 시 `selectedYear`가 자동 포함되어 현재 연도 데이터만 조회되던 문제 해결
- 기간 선택과 연도 선택을 명확히 분리하여, 불필요한 파라미터 전달 방지 및 데이터 조회의 정확도 향상