### PR TITLE
fix: include year parameter when period is set to year

### DIFF
--- a/src/lib/hooks/useAnalyticsHandlers.ts
+++ b/src/lib/hooks/useAnalyticsHandlers.ts
@@ -7,12 +7,10 @@ export const useAnalyticsHandlers = () => {
     const handlePeriodChange = (e: ChangeEvent<HTMLSelectElement>) => {
         const newPeriod = e.target.value as 'day' | 'week' | 'month' | 'year' | 'all';
         setPeriod(newPeriod);
-        const params: { period: typeof newPeriod; year?: number } = { period: newPeriod };
         if (newPeriod === 'year') {
-            fetchAnalytics({ period: newPeriod });
+            fetchAnalytics({ period: newPeriod, year: selectedYear });
         } else {
-            delete params.year;
-            fetchAnalytics(params);
+            fetchAnalytics({ period: newPeriod });
         }
     };
 


### PR DESCRIPTION
## 변경사항
- `period`가 `year`로 설정될 때 `selectedYear` 파라미터가 포함되도록 수정

## 목적
- 연도 기반 데이터 조회 시, 전체 데이터가 나오는 이슈 해결을 위한 수정